### PR TITLE
Scene router

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "deploy": "npm run build && firebase deploy",
     "dev": "npm run elm-dev & npm run css-dev & npm run js-dev",
-    "build": "npm run elm-build & npm run js-build & npm run css-build",
+    "build": "npm run elm-build && npm run js-build && npm run css-build",
     "elm-dev": "elm-live src/elm/App.elm --output=public/main.js --dir=public --open --debug --pushstate",
     "elm-build": "elm-make src/elm/App.elm --output=public/main.js && npm run compress-main",
     "css-dev": "postcss --watch --config ./postcss-config.js",

--- a/src/elm/Config/World/One.elm
+++ b/src/elm/Config/World/One.elm
@@ -101,7 +101,7 @@ levels =
                 ]
           }
         , { walls = yellowWalls sixthLevelWalls
-          , moves = 10
+          , moves = 20
           , tutorial = Nothing
           , boardDimensions = { x = 7, y = 7 }
           , tileSettings =

--- a/src/elm/Data/Board/Move/Square.elm
+++ b/src/elm/Data/Board/Move/Square.elm
@@ -11,7 +11,7 @@ import Data.Board.Move.Bearing exposing (validDirection)
 import Data.Board.Moves exposing (..)
 import Data.Board.Types exposing (..)
 import Dict
-import Helpers.Effect exposing (trigger)
+import Helpers.Delay exposing (trigger)
 import List exposing (all)
 
 

--- a/src/elm/Helpers/Delay.elm
+++ b/src/elm/Helpers/Delay.elm
@@ -1,14 +1,8 @@
-module Helpers.Effect exposing (..)
+module Helpers.Delay exposing (..)
 
 import Delay
-import Dom
-import Dom.Scroll exposing (toY)
 import Task
 import Time exposing (millisecond)
-import Window exposing (Size, resizes, size)
-
-
--- Delay Helpers
 
 
 sequenceMs : List ( Float, msg ) -> Cmd msg
@@ -28,16 +22,3 @@ pause pauseDuration steps =
         |> Maybe.map (\( n, msg ) -> ( n + pauseDuration, msg ))
         |> Maybe.map (\newDelay -> [ newDelay ] ++ (List.drop 1 steps))
         |> Maybe.withDefault []
-
-
-
--- Dom Scroll Helpers
-
-
-scrollHubToLevel : (Result Dom.Error () -> msg) -> Float -> Size -> Cmd msg
-scrollHubToLevel msg offset window =
-    let
-        targetDistance =
-            offset - toFloat (window.height // 2) + 60
-    in
-        toY "hub" targetDistance |> Task.attempt msg

--- a/src/elm/Helpers/Delay.elm
+++ b/src/elm/Helpers/Delay.elm
@@ -10,6 +10,11 @@ sequenceMs steps =
     Delay.sequence <| Delay.withUnit millisecond <| steps
 
 
+delayMs : Float -> msg -> Cmd msg
+delayMs time =
+    Delay.after time millisecond
+
+
 trigger : msg -> Cmd msg
 trigger msg =
     Task.succeed msg |> Task.perform identity

--- a/src/elm/Scenes/Hub/View.elm
+++ b/src/elm/Scenes/Hub/View.elm
@@ -1,16 +1,18 @@
 module Scenes.Hub.View exposing (..)
 
 import Config.Color exposing (darkYellow, pinkRed, washedYellow)
+import Data.Transit exposing (Transit(..))
 import Date exposing (minute, second)
 import Helpers.Css.Style exposing (..)
 import Helpers.Css.Transform exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import State exposing (livesLeft)
 import Time exposing (Time)
 import Types exposing (..)
 import Views.Hub.InfoWindow exposing (handleHideInfo, info)
 import Views.Hub.World exposing (renderWorlds)
-import Views.Lives exposing (livesLeft)
+import Views.Lives exposing (renderLivesLeft)
 
 
 hubView : Model -> Html Msg
@@ -29,13 +31,20 @@ hubView model =
 
 hubTopBar : Model -> Html msg
 hubTopBar model =
-    div
-        [ class "w-100 fixed z-3 top-0 tc pa1 pa2-ns"
-        , style [ background washedYellow ]
-        ]
-        [ div [ style [ transformStyle [ scale 0.5 ] ] ] <| livesLeft model.lives
-        , div [ class "f7", style [ color darkYellow ] ] [ renderCountDown model.timeTillNextLife ]
-        ]
+    let
+        lives =
+            model.timeTillNextLife
+                |> livesLeft
+                |> floor
+                |> Transitioning
+    in
+        div
+            [ class "w-100 fixed z-3 top-0 tc pa1 pa2-ns"
+            , style [ background washedYellow ]
+            ]
+            [ div [ style [ transformStyle [ scale 0.5 ] ] ] <| renderLivesLeft lives
+            , div [ class "f7", style [ color darkYellow ] ] [ renderCountDown model.timeTillNextLife ]
+            ]
 
 
 renderCountDown : Time -> Html msg

--- a/src/elm/Scenes/Level/State.elm
+++ b/src/elm/Scenes/Level/State.elm
@@ -62,7 +62,7 @@ initialState =
     , boardDimensions = { y = 8, x = 8 }
     , levelStatus = InProgress
     , successMessageIndex = 0
-    , levelInfoWindow = Hidden
+    , hubInfoWindow = Hidden
     , mouse = { y = 0, x = 0 }
     , window = { height = 0, width = 0 }
     }
@@ -166,13 +166,13 @@ update msg model =
             noOutMsg { model | successMessageIndex = i } []
 
         ShowInfo info ->
-            noOutMsg { model | levelInfoWindow = Visible info } []
+            noOutMsg { model | hubInfoWindow = Visible info } []
 
         RemoveInfo ->
-            noOutMsg { model | levelInfoWindow = InfoWindow.toHiding model.levelInfoWindow } []
+            noOutMsg { model | hubInfoWindow = InfoWindow.toHiding model.hubInfoWindow } []
 
         InfoHidden ->
-            noOutMsg { model | levelInfoWindow = Hidden } []
+            noOutMsg { model | hubInfoWindow = Hidden } []
 
         LevelWon ->
             -- outMsg signals to parent component that level has been won

--- a/src/elm/Scenes/Level/State.elm
+++ b/src/elm/Scenes/Level/State.elm
@@ -26,13 +26,17 @@ import Window exposing (resizes, size)
 -- Init
 
 
-init : LevelData tutorialConfig -> Model -> ( Model, Cmd Msg )
-init levelData model =
-    addLevelData levelData model
-        ! [ handleGenerateTiles levelData model
-          , getWindowSize
-          , generateSuccessMessageIndex
-          ]
+init : LevelData tutorialConfig -> ( Model, Cmd Msg )
+init levelData =
+    let
+        model =
+            addLevelData levelData initialState
+    in
+        model
+            ! [ handleGenerateTiles levelData model
+              , getWindowSize
+              , generateSuccessMessageIndex
+              ]
 
 
 addLevelData : LevelData tutorialConfig -> Model -> Model

--- a/src/elm/Scenes/Level/State.elm
+++ b/src/elm/Scenes/Level/State.elm
@@ -8,15 +8,16 @@ import Data.Board.Map exposing (..)
 import Data.Board.Move.Check exposing (addToMove, startMove)
 import Data.Board.Move.Square exposing (setAllTilesOfTypeToDragging, triggerMoveIfSquare)
 import Data.Board.Moves exposing (currentMoveTileType)
+import Data.Board.Score exposing (addScoreFromMoves, initialScores, levelComplete)
 import Data.Board.Shift exposing (shiftBoard)
 import Data.Board.Types exposing (..)
 import Data.Board.Wall exposing (addWalls)
 import Data.InfoWindow as InfoWindow exposing (InfoWindow(..))
-import Data.Board.Score exposing (addScoreFromMoves, initialScores, levelComplete)
 import Data.Level.Types exposing (LevelData)
 import Dict
-import Helpers.Effect exposing (sequenceMs, trigger)
+import Helpers.Delay exposing (sequenceMs, trigger)
 import Helpers.OutMsg exposing (noOutMsg, withOutMsg)
+import Mouse exposing (downs, moves)
 import Scenes.Level.Types exposing (..)
 
 
@@ -170,6 +171,9 @@ update msg model =
         LevelLost ->
             -- outMsg signals to parent component that level has been lost
             withOutMsg model [] ExitLevelWithLose
+
+        MousePosition position ->
+            noOutMsg { model | mouse = position } []
 
 
 
@@ -332,3 +336,23 @@ hasLost { remainingMoves, levelStatus } =
 hasWon : Model -> Bool
 hasWon { scores, levelStatus } =
     levelComplete scores && levelStatus == InProgress
+
+
+
+-- subscriptions
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.batch
+        [ subscribeDrag model
+        , downs MousePosition
+        ]
+
+
+subscribeDrag : Model -> Sub Msg
+subscribeDrag model =
+    if model.isDragging then
+        moves MousePosition
+    else
+        Sub.none

--- a/src/elm/Scenes/Level/State.elm
+++ b/src/elm/Scenes/Level/State.elm
@@ -19,6 +19,8 @@ import Helpers.Delay exposing (sequenceMs, trigger)
 import Helpers.OutMsg exposing (noOutMsg, withOutMsg)
 import Mouse exposing (downs, moves)
 import Scenes.Level.Types exposing (..)
+import Task
+import Window exposing (resizes, size)
 
 
 -- Init
@@ -26,12 +28,11 @@ import Scenes.Level.Types exposing (..)
 
 init : LevelData tutorialConfig -> Model -> ( Model, Cmd Msg )
 init levelData model =
-    addLevelData levelData model |> generateTiles levelData
-
-
-generateTiles : LevelData tutorialConfig -> Model -> ( Model, Cmd Msg )
-generateTiles levelData model =
-    model ! [ handleGenerateTiles levelData model ]
+    addLevelData levelData model
+        ! [ handleGenerateTiles levelData model
+          , getWindowSize
+          , generateSuccessMessageIndex
+          ]
 
 
 addLevelData : LevelData tutorialConfig -> Model -> Model
@@ -61,6 +62,11 @@ initialState =
     , mouse = { y = 0, x = 0 }
     , window = { height = 0, width = 0 }
     }
+
+
+getWindowSize : Cmd Msg
+getWindowSize =
+    Task.perform WindowSize size
 
 
 generateSuccessMessageIndex : Cmd Msg
@@ -174,6 +180,9 @@ update msg model =
 
         MousePosition position ->
             noOutMsg { model | mouse = position } []
+
+        WindowSize size ->
+            noOutMsg { model | window = size } []
 
 
 
@@ -347,6 +356,7 @@ subscriptions model =
     Sub.batch
         [ subscribeDrag model
         , downs MousePosition
+        , resizes WindowSize
         ]
 
 

--- a/src/elm/Scenes/Level/Types.elm
+++ b/src/elm/Scenes/Level/Types.elm
@@ -16,7 +16,7 @@ type alias Model =
     , tileSettings : List TileSetting
     , boardDimensions : BoardDimensions
     , levelStatus : LevelStatus
-    , levelInfoWindow : InfoWindow String
+    , hubInfoWindow : InfoWindow String
     , successMessageIndex : Int
     , mouse : Mouse.Position
     , window : Window.Size

--- a/src/elm/Scenes/Level/Types.elm
+++ b/src/elm/Scenes/Level/Types.elm
@@ -48,6 +48,7 @@ type Msg
     | LevelWon
     | LevelLost
     | MousePosition Mouse.Position
+    | WindowSize Window.Size
 
 
 type OutMsg

--- a/src/elm/Scenes/Level/Types.elm
+++ b/src/elm/Scenes/Level/Types.elm
@@ -47,6 +47,7 @@ type Msg
     | InfoHidden
     | LevelWon
     | LevelLost
+    | MousePosition Mouse.Position
 
 
 type OutMsg

--- a/src/elm/Scenes/Retry/View.elm
+++ b/src/elm/Scenes/Retry/View.elm
@@ -1,6 +1,7 @@
 module Scenes.Retry.View exposing (..)
 
 import Config.Color exposing (..)
+import Data.Transit exposing (Transit(..))
 import Helpers.Css.Animation exposing (..)
 import Helpers.Css.Style exposing (..)
 import Helpers.Css.Timing exposing (..)
@@ -8,8 +9,9 @@ import Helpers.Css.Transform exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
+import State exposing (livesLeft)
 import Types exposing (..)
-import Views.Lives exposing (livesLeft)
+import Views.Lives exposing (renderLivesLeft)
 
 
 retryView : Model -> Html Msg
@@ -27,7 +29,7 @@ retryView model =
             ]
         ]
         [ div [ class "tc", style [ ( "margin-top", pc -8 ) ] ]
-            [ div [] <| livesLeft model.lives
+            [ div [] <| renderLivesLeft <| lifeState model
             , div [ style [ color darkYellow ] ]
                 [ p [ class "mt3" ] [ text "You lost a life ..." ]
                 , p
@@ -61,6 +63,20 @@ retryView model =
                 [ tryAgain model ]
             ]
         ]
+
+
+lifeState : Model -> Transit Int
+lifeState model =
+    let
+        lives =
+            model.timeTillNextLife |> livesLeft |> floor
+    in
+        case model.scene of
+            Transition _ ->
+                Static lives
+
+            _ ->
+                Transitioning lives
 
 
 tryAgain : Model -> Html Msg

--- a/src/elm/Scenes/Tutorial/State.elm
+++ b/src/elm/Scenes/Tutorial/State.elm
@@ -12,6 +12,8 @@ import Helpers.Delay exposing (pause, sequenceMs, trigger)
 import Helpers.OutMsg exposing (noOutMsg, withOutMsg)
 import Scenes.Level.State exposing (handleInsertEnteringTiles)
 import Scenes.Tutorial.Types exposing (..)
+import Task
+import Window exposing (resizes, size)
 
 
 -- Init
@@ -19,7 +21,15 @@ import Scenes.Tutorial.Types exposing (..)
 
 init : Config -> ( Model, Cmd Msg )
 init config =
-    loadTutorialData config initialState ! [ sequenceMs config.sequence ]
+    loadTutorialData config initialState
+        ! [ sequenceMs config.sequence
+          , getWindowSize
+          ]
+
+
+getWindowSize : Cmd Msg
+getWindowSize =
+    Task.perform WindowSize size
 
 
 initialState : Model
@@ -143,6 +153,9 @@ update msg model =
         ExitTutorial ->
             withOutMsg model [ trigger ResetVisibilities ] ExitTutorialToLevel
 
+        WindowSize size ->
+            noOutMsg { model | window = size } []
+
 
 
 -- Update Helpers
@@ -183,3 +196,8 @@ handleDragTile coord model =
             Dict.get coord model.board |> Maybe.withDefault sunflower
     in
         { model | board = addBearings ( coord, tile ) model.board }
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    resizes WindowSize

--- a/src/elm/Scenes/Tutorial/State.elm
+++ b/src/elm/Scenes/Tutorial/State.elm
@@ -27,10 +27,10 @@ init levelData config =
             loadTutorialData config initialState
 
         ( levelModel, levelCmd ) =
-            Level.init levelData Level.initialState
+            Level.init levelData
     in
         { model | levelModel = levelModel }
-            ! [ sequenceMs config.sequence
+            ! [ sequenceMs <| pause 500 config.sequence
               , getWindowSize
               , Cmd.map LevelMsg levelCmd
               ]

--- a/src/elm/Scenes/Tutorial/State.elm
+++ b/src/elm/Scenes/Tutorial/State.elm
@@ -8,7 +8,7 @@ import Data.Board.Move.Square exposing (setAllTilesOfTypeToDragging)
 import Data.Board.Shift exposing (shiftBoard)
 import Data.Board.Types exposing (..)
 import Dict
-import Helpers.Effect exposing (pause, sequenceMs, trigger)
+import Helpers.Delay exposing (pause, sequenceMs, trigger)
 import Helpers.OutMsg exposing (noOutMsg, withOutMsg)
 import Scenes.Level.State exposing (handleInsertEnteringTiles)
 import Scenes.Tutorial.Types exposing (..)

--- a/src/elm/Scenes/Tutorial/Types.elm
+++ b/src/elm/Scenes/Tutorial/Types.elm
@@ -3,6 +3,7 @@ module Scenes.Tutorial.Types exposing (..)
 import Data.Board.Types exposing (Board, BoardDimensions, Coord, MoveShape, SeedType, TileType)
 import Dict exposing (Dict)
 import Window
+import Scenes.Level.Types as Level
 
 
 type alias Model =
@@ -19,6 +20,7 @@ type alias Model =
     , currentText : Int
     , text : Dict Int String
     , window : Window.Size
+    , levelModel : Level.Model
     }
 
 
@@ -36,7 +38,8 @@ type alias Sequence =
 
 
 type Msg
-    = DragTile Coord
+    = LevelMsg Level.Msg
+    | DragTile Coord
     | SetGrowingPods
     | SetLeaving
     | ResetLeaving

--- a/src/elm/Scenes/Tutorial/Types.elm
+++ b/src/elm/Scenes/Tutorial/Types.elm
@@ -62,6 +62,7 @@ type Msg
     | SkipTutorial
     | DisableTutorial
     | ExitTutorial
+    | WindowSize Window.Size
 
 
 type OutMsg

--- a/src/elm/Scenes/Tutorial/View.elm
+++ b/src/elm/Scenes/Tutorial/View.elm
@@ -10,6 +10,7 @@ import Helpers.Css.Style exposing (..)
 import Helpers.Css.Timing exposing (TimingFunction(..))
 import Helpers.Css.Transform exposing (..)
 import Helpers.Css.Transition exposing (easeAll, transitionStyle)
+import Helpers.Html exposing (emptyProperty)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
@@ -59,7 +60,7 @@ tutorialView model =
                 [ text <| getText model.text model.currentText ]
             ]
         , p
-            [ onClick SkipTutorial
+            [ handleSkip model
             , style
                 [ color greyYellow
                 , bottomStyle 30
@@ -75,6 +76,14 @@ tutorialView model =
             ]
             [ text "skip" ]
         ]
+
+
+handleSkip : Model -> Attribute Msg
+handleSkip model =
+    if not model.skipped then
+        onClick SkipTutorial
+    else
+        emptyProperty
 
 
 tutorialBoard : Model -> Html msg

--- a/src/elm/State.elm
+++ b/src/elm/State.elm
@@ -43,7 +43,6 @@ initialState flags =
     , loadingScreen = Nothing
     , progress = initProgressFromCache flags.rawProgress
     , currentLevel = Nothing
-    , lives = Transitioning 5
     , levelInfoWindow = Hidden
     , window = { height = 0, width = 0 }
     , lastPlayed = initLastPlayed flags
@@ -160,11 +159,7 @@ update msg model =
             handleIncrementProgress model
 
         DecrementLives ->
-            (model
-                |> handleDecrementLives
-                |> addTimeTillNextLife
-            )
-                ! []
+            addTimeTillNextLife model ! []
 
         ScrollToHubLevel level ->
             model ! [ scrollToHubLevel level ]
@@ -230,10 +225,7 @@ handleLoadRetry : Model -> Model
 handleLoadRetry model =
     case model.scene of
         Loaded (Level levelModel) ->
-            { model
-                | scene = Transition { from = Level levelModel, to = Retry }
-                , lives = Transit.toStatic model.lives
-            }
+            { model | scene = Transition { from = Level levelModel, to = Retry } }
 
         _ ->
             model
@@ -453,7 +445,6 @@ countDownToNextLife now model =
             { model
                 | timeTillNextLife = newTimeTillNextLife
                 , lastPlayed = now
-                , lives = Transit.map (always lifeVal) model.lives
             }
 
 
@@ -470,11 +461,6 @@ livesLeft timeTill =
 addTimeTillNextLife : Model -> Model
 addTimeTillNextLife model =
     { model | timeTillNextLife = model.timeTillNextLife + lifeRecoveryInterval }
-
-
-handleDecrementLives : Model -> Model
-handleDecrementLives model =
-    { model | lives = decrementLives model.lives }
 
 
 decrementLives : Transit Int -> Transit Int

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -31,7 +31,7 @@ type alias RawProgress =
 
 
 type alias Model =
-    { scene : Scene
+    { scene : SceneState
     , loadingScreen : Maybe Background
     , progress : Progress
     , currentLevel : Maybe Progress
@@ -44,17 +44,24 @@ type alias Model =
     }
 
 
+type SceneState
+    = Transition SceneTransition
+    | Loaded Scene
+
+
+type alias SceneTransition =
+    { from : Scene
+    , to : Scene
+    }
+
+
 type Scene
     = Title
     | Hub
-    | Tutorial Tutorial.Model (Backdrop Level.Model)
+    | Tutorial Tutorial.Model
     | Level Level.Model
-    | Summary (Backdrop Level.Model)
-    | Retry (Backdrop Level.Model)
-
-
-type Backdrop a
-    = Backdrop a
+    | Summary
+    | Retry
 
 
 type Msg
@@ -65,10 +72,11 @@ type Msg
     | TransitionWithWin
     | TransitionWithLose
     | LoadTutorial Progress Tutorial.Config
-    | LoadLevel (LevelData Tutorial.Config)
+    | LoadLevel Progress
     | LoadHub
     | LoadSummary
     | LoadRetry
+    | CompleteSceneTransition
     | ShowLoadingScreen
     | HideLoadingScreen
     | RandomBackground Background

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -3,7 +3,6 @@ module Types exposing (..)
 import Data.Background exposing (Background)
 import Data.InfoWindow exposing (InfoWindow)
 import Data.Level.Types exposing (LevelData, Progress)
-import Data.Transit exposing (Transit)
 import Dom
 import Scenes.Level.Types as Level exposing (..)
 import Scenes.Tutorial.Types as Tutorial
@@ -35,10 +34,9 @@ type alias Model =
     , loadingScreen : Maybe Background
     , progress : Progress
     , currentLevel : Maybe Progress
-    , lives : Transit Int
     , levelInfoWindow : InfoWindow Progress
-    , lastPlayed : Time
     , timeTillNextLife : Time
+    , lastPlayed : Time
     , window : Window.Size
     , xAnimations : String
     }

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -34,11 +34,11 @@ type alias Model =
     , loadingScreen : Maybe Background
     , progress : Progress
     , currentLevel : Maybe Progress
-    , levelInfoWindow : InfoWindow Progress
     , timeTillNextLife : Time
     , lastPlayed : Time
     , window : Window.Size
     , xAnimations : String
+    , hubInfoWindow : InfoWindow Progress
     }
 
 
@@ -80,30 +80,17 @@ type Msg
     | RandomBackground Background
     | SetCurrentLevel (Maybe Progress)
     | GoToHub
-    | ShowInfo Progress
-    | HideInfo
-    | SetInfoState (InfoWindow Progress)
-    | IncrementProgress
-    | DecrementLives
-    | ScrollToHubLevel Int
-    | ReceiveHubLevelOffset Float
     | ReceieveExternalAnimations String
     | ClearCache
     | DomNoOp (Result Dom.Error ())
     | WindowSize Window.Size
     | UpdateTimes Time
-
-
-fromProgress : Progress -> RawProgress
-fromProgress ( world, level ) =
-    RawProgress world level
-
-
-toProgress : Maybe RawProgress -> Maybe Progress
-toProgress =
-    Maybe.map toProgress_
-
-
-toProgress_ : RawProgress -> Progress
-toProgress_ { world, level } =
-    ( world, level )
+      -- Summary and Retry Specific Messages
+    | IncrementProgress
+    | DecrementLives
+      -- Hub Specific Messages
+    | ShowLevelInfo Progress
+    | HideLevelInfo
+    | SetInfoState (InfoWindow Progress)
+    | ScrollHubToLevel Int
+    | ReceiveHubLevelOffset Float

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -93,7 +93,7 @@ type Msg
     | ClearCache
     | DomNoOp (Result Dom.Error ())
     | WindowSize Window.Size
-    | Tick Time
+    | UpdateTimes Time
 
 
 fromProgress : Progress -> RawProgress

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -30,14 +30,8 @@ type alias RawProgress =
     }
 
 
-type alias HasWindow model =
-    { model | window : Window.Size }
-
-
 type alias Model =
-    { levelModel : Level.Model
-    , tutorialModel : Tutorial.Model
-    , scene : Scene
+    { scene : Scene
     , loadingScreen : Maybe Background
     , progress : Progress
     , currentLevel : Maybe Progress
@@ -50,6 +44,19 @@ type alias Model =
     }
 
 
+type Scene
+    = Title
+    | Hub
+    | Tutorial Tutorial.Model (Backdrop Level.Model)
+    | Level Level.Model
+    | Summary (Backdrop Level.Model)
+    | Retry (Backdrop Level.Model)
+
+
+type Backdrop a
+    = Backdrop a
+
+
 type Msg
     = LevelMsg Level.Msg
     | TutorialMsg Tutorial.Msg
@@ -57,15 +64,16 @@ type Msg
     | RestartLevel
     | TransitionWithWin
     | TransitionWithLose
-    | LoadTutorial Tutorial.Config
+    | LoadTutorial Progress Tutorial.Config
     | LoadLevel (LevelData Tutorial.Config)
-    | SetScene Scene
+    | LoadHub
+    | LoadSummary
+    | LoadRetry
     | ShowLoadingScreen
     | HideLoadingScreen
     | RandomBackground Background
     | SetCurrentLevel (Maybe Progress)
     | GoToHub
-    | GoToRetry
     | ShowInfo Progress
     | HideInfo
     | SetInfoState (InfoWindow Progress)
@@ -78,15 +86,6 @@ type Msg
     | DomNoOp (Result Dom.Error ())
     | WindowSize Window.Size
     | Tick Time
-
-
-type Scene
-    = Level
-    | Hub
-    | Title
-    | Tutorial
-    | Summary
-    | Retry
 
 
 fromProgress : Progress -> RawProgress

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -5,7 +5,6 @@ import Data.InfoWindow exposing (InfoWindow)
 import Data.Level.Types exposing (LevelData, Progress)
 import Data.Transit exposing (Transit)
 import Dom
-import Mouse
 import Scenes.Level.Types as Level exposing (..)
 import Scenes.Tutorial.Types as Tutorial
 import Time exposing (Time)
@@ -31,10 +30,13 @@ type alias RawProgress =
     }
 
 
+type alias HasWindow model =
+    { model | window : Window.Size }
+
+
 type alias Model =
     { levelModel : Level.Model
     , tutorialModel : Tutorial.Model
-    , xAnimations : String
     , scene : Scene
     , sceneTransition : Bool
     , transitionBackground : Background
@@ -42,10 +44,10 @@ type alias Model =
     , currentLevel : Maybe Progress
     , lives : Transit Int
     , levelInfoWindow : InfoWindow Progress
-    , window : Window.Size
-    , mouse : Mouse.Position
     , lastPlayed : Time
     , timeTillNextLife : Time
+    , window : Window.Size
+    , xAnimations : String
     }
 
 
@@ -76,7 +78,6 @@ type Msg
     | ClearCache
     | DomNoOp (Result Dom.Error ())
     | WindowSize Window.Size
-    | MousePosition Mouse.Position
     | Tick Time
 
 

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -38,8 +38,7 @@ type alias Model =
     { levelModel : Level.Model
     , tutorialModel : Tutorial.Model
     , scene : Scene
-    , sceneTransition : Bool
-    , transitionBackground : Background
+    , loadingScreen : Maybe Background
     , progress : Progress
     , currentLevel : Maybe Progress
     , lives : Transit Int
@@ -61,8 +60,8 @@ type Msg
     | LoadTutorial Tutorial.Config
     | LoadLevel (LevelData Tutorial.Config)
     | SetScene Scene
-    | BeginSceneTransition
-    | EndSceneTransition
+    | ShowLoadingScreen
+    | HideLoadingScreen
     | RandomBackground Background
     | SetCurrentLevel (Maybe Progress)
     | GoToHub

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -14,7 +14,7 @@ import Scenes.Retry.View exposing (retryView)
 import Scenes.Summary.View exposing (summaryView)
 import Scenes.Title.View exposing (titleView)
 import Scenes.Tutorial.View exposing (tutorialView)
-import Types exposing (Model, Msg(..), Scene(..))
+import Types exposing (Backdrop(..), Model, Msg(..), Scene(..))
 import Views.Backdrop exposing (backdrop)
 import Views.Loading exposing (loadingScreen)
 
@@ -41,36 +41,35 @@ embeddedAnimations externalanimations =
 renderScene : Model -> Html Msg
 renderScene model =
     let
-        keyedDiv =
+        kd =
             K.node "div" []
     in
         case model.scene of
             Hub ->
-                hubView model
+                kd [ ( "hub", hubView model ) ]
 
             Title ->
-                titleView model
+                kd [ ( "title", titleView model ) ]
 
-            Level ->
-                keyedDiv
-                    [ ( "level", levelView model.levelModel |> Html.map LevelMsg ) ]
+            Level levelModel ->
+                kd [ ( "level", levelView levelModel |> Html.map LevelMsg ) ]
 
-            Summary ->
-                keyedDiv
+            Summary (Backdrop levelModel) ->
+                kd
                     [ ( "summary", summaryView model )
-                    , ( "level", levelView model.levelModel |> Html.map LevelMsg )
+                    , ( "level", levelView levelModel |> Html.map LevelMsg )
                     ]
 
-            Retry ->
-                keyedDiv
+            Retry (Backdrop levelModel) ->
+                kd
                     [ ( "retry", retryView model )
-                    , ( "level", levelView model.levelModel |> Html.map LevelMsg )
+                    , ( "level", levelView levelModel |> Html.map LevelMsg )
                     ]
 
-            Tutorial ->
-                keyedDiv
-                    [ ( "tutorial", tutorialView model.tutorialModel |> Html.map TutorialMsg )
-                    , ( "level", levelView model.levelModel |> Html.map LevelMsg )
+            Tutorial tutorialModel (Backdrop levelModel) ->
+                kd
+                    [ ( "tutorial", tutorialView tutorialModel |> Html.map TutorialMsg )
+                    , ( "level", levelView levelModel |> Html.map LevelMsg )
                     ]
 
 

--- a/src/elm/Views/Hub/InfoWindow.elm
+++ b/src/elm/Views/Hub/InfoWindow.elm
@@ -20,7 +20,7 @@ import Views.Seed.All exposing (renderSeed)
 
 info : Model -> Html Msg
 info model =
-    case model.levelInfoWindow of
+    case model.hubInfoWindow of
         Hidden ->
             span [] []
 
@@ -29,7 +29,7 @@ info model =
                 content =
                     getLevelConfig progress |> infoContent progress
             in
-                infoContainer model.levelInfoWindow <|
+                infoContainer model.hubInfoWindow <|
                     div [ onClick <| StartLevel progress ] content
 
         Hiding progress ->
@@ -37,7 +37,7 @@ info model =
                 content =
                     getLevelConfig progress |> infoContent progress
             in
-                infoContainer model.levelInfoWindow <|
+                infoContainer model.hubInfoWindow <|
                     div [] content
 
 
@@ -126,9 +126,9 @@ renderWeather color =
 
 handleHideInfo : Model -> Attribute Msg
 handleHideInfo model =
-    case model.levelInfoWindow of
+    case model.hubInfoWindow of
         Visible _ ->
-            onClick HideInfo
+            onClick HideLevelInfo
 
         _ ->
             emptyProperty

--- a/src/elm/Views/Hub/World.elm
+++ b/src/elm/Views/Hub/World.elm
@@ -109,8 +109,8 @@ renderNumber visibleLevelNumber currentLevel worldData model =
 
 showInfo : Progress -> Model -> Attribute Msg
 showInfo currentLevel model =
-    if reachedLevel allLevels currentLevel model.progress && model.levelInfoWindow == Hidden then
-        onClick <| ShowInfo currentLevel
+    if reachedLevel allLevels currentLevel model.progress && model.hubInfoWindow == Hidden then
+        onClick <| ShowLevelInfo currentLevel
     else
         emptyProperty
 

--- a/src/elm/Views/Level/Result.elm
+++ b/src/elm/Views/Level/Result.elm
@@ -9,14 +9,14 @@ import Views.InfoWindow exposing (infoContainer)
 
 infoWindow : Model -> Html msg
 infoWindow model =
-    case model.levelInfoWindow of
+    case model.hubInfoWindow of
         Hidden ->
             span [] []
 
         Visible message ->
-            infoContainer model.levelInfoWindow <|
+            infoContainer model.hubInfoWindow <|
                 div [ class "pv5 f3 tracked-mega" ] [ text message ]
 
         Hiding message ->
-            infoContainer model.levelInfoWindow <|
+            infoContainer model.hubInfoWindow <|
                 div [ class "pv5 f3 tracked-mega" ] [ text message ]

--- a/src/elm/Views/Lives.elm
+++ b/src/elm/Views/Lives.elm
@@ -10,8 +10,8 @@ import Html.Attributes exposing (..)
 import Views.Icons.Heart exposing (..)
 
 
-livesLeft : Transit Int -> List (Html msg)
-livesLeft lifeState =
+renderLivesLeft : Transit Int -> List (Html msg)
+renderLivesLeft lifeState =
     let
         lives =
             Transit.val lifeState

--- a/src/elm/Views/Loading.elm
+++ b/src/elm/Views/Loading.elm
@@ -4,7 +4,7 @@ import Config.Color exposing (gold, rainBlue)
 import Config.Levels exposing (allLevels)
 import Data.Background exposing (..)
 import Data.Level.Progress exposing (currentLevelSeedType)
-import Helpers.Css.Style exposing (backgroundColor, classes, widthStyle)
+import Helpers.Css.Style exposing (Style, backgroundColor, classes, emptyStyle, widthStyle)
 import Helpers.Css.Transition exposing (easeAll)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -20,7 +20,7 @@ loadingScreen model =
             , transitionClasses model
             ]
         , style
-            [ backgroundColor <| loadingBackground model.transitionBackground
+            [ loadingScreenBackground model.loadingScreen
             , easeAll 500
             ]
         ]
@@ -30,8 +30,15 @@ loadingScreen model =
         ]
 
 
-loadingBackground : Background -> String
-loadingBackground bg =
+loadingScreenBackground : Maybe Background -> Style
+loadingScreenBackground sceneTransition =
+    sceneTransition
+        |> Maybe.map (loadingScreenColor >> backgroundColor)
+        |> Maybe.withDefault emptyStyle
+
+
+loadingScreenColor : Background -> String
+loadingScreenColor bg =
     case bg of
         Blue ->
             rainBlue
@@ -42,7 +49,9 @@ loadingBackground bg =
 
 transitionClasses : Model -> String
 transitionClasses model =
-    if model.sceneTransition then
-        "o-100"
-    else
-        "o-0 touch-disabled"
+    case model.loadingScreen of
+        Just _ ->
+            "o-100"
+
+        Nothing ->
+            "o-0 touch-disabled"

--- a/src/js/cache.js
+++ b/src/js/cache.js
@@ -20,9 +20,9 @@ function clear () {
   localStorage.clear()
 }
 
-function safeParse (rawJSON) {
+function safeParse (JSONstring) {
   try {
-    return JSON.parse(rawJSON)
+    return JSON.parse(JSONstring)
   } catch (e) {
     return null
   }


### PR DESCRIPTION
+ Scene models mostly consolidated in `Scene` type
+ `Level` model now child of `Tutorial` model during `Tutorial` scene (facilitates the level faintly visible in the background)
+ Transitioning to `Level` swaps sub model into `Level` scene
+ Removes redundant `Level` and `Tutorial` models during `Hub`, `Title`, `Retry` and `Summary` scenes
+ Use absolute time for calculating timeToNextLife
+ Timer ticks quickly during `Hub` scene to render countdown more accurately